### PR TITLE
feat: add opt-in skip_if_exists to reverse-download

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -224,6 +224,7 @@ class ReverseDownloadRequest(BaseModel):
     metadata: Optional[Dict] = None
     provider: Optional[str] = None  # "deezer" | "spotify"
     navidrome_library: Optional[str] = None
+    skip_if_exists: Optional[bool] = False  # Opt-in: skip (don't re-download/overwrite) if the track already exists at the target location. Default False preserves existing behavior.
 
 
 # Response models
@@ -631,6 +632,7 @@ def reverse_download_and_process(
     metadata: Optional[Dict],
     metadata_provider: str = "deezer",
     navidrome_library_path: Optional[str] = None,
+    skip_if_exists: bool = False,
 ):
     """Background task: download a specific YouTube URL and tag using catalog or manual metadata."""
     try:
@@ -690,6 +692,11 @@ def reverse_download_and_process(
                 'external_url': yt_info.get('webpage_url') or youtube_url,
                 'preview_url': None,
             }
+
+        if skip_if_exists and physical_track_file_exists(track_info, location, config.OUTPUT_FORMAT, navidrome_library_path):
+            upsert_job(job_id, status="skipped", message="Track already exists at the target location, skipped",
+                       stage="skipped", progress=100)
+            return
 
         upsert_job(job_id, status="processing", message="Preparing download location...", stage="preparing",
                    progress=20)
@@ -795,6 +802,7 @@ async def reverse_download(request: ReverseDownloadRequest, background_tasks: Ba
         request.metadata,
         provider,
         navidrome_path,
+        request.skip_if_exists or False,
     )
 
     return {


### PR DESCRIPTION
## Add opt-in `skip_if_exists` to `/api/reverse/download`

### The problem

The reverse-download duplicate check (`get_duplicate_download_reason` → `physical_track_file_exists`) only runs when the request includes a `spotify_track_id` — i.e. only on the catalog-search reverse flow. When calling `/api/reverse/download` with **manual metadata** (no catalog track backing it — the flow meant for "I already know exactly which YouTube video I want"), that check is skipped entirely.

In practice: calling the endpoint twice for the same track re-downloads it from YouTube and silently overwrites the file already sitting in the library via `shutil.copy2`. No error, no signal — it just quietly redoes the work.

This shows up for any integration that pushes tracks by URL + manual metadata instead of searching the catalog first — for example, a media client that reports "the user actually listened to this" and pushes straight to Musikat without a Deezer/Spotify ID in hand.

### The fix

Adds an **opt-in** `skip_if_exists` field to `ReverseDownloadRequest` (default `false` — existing behavior is untouched for everyone not using it):

```json
{
  "youtube_url": "https://music.youtube.com/watch?v=...",
  "location": "navidrome",
  "metadata": { "name": "...", "artist": "...", "album": "..." },
  "skip_if_exists": true
}
```

When `true`, the existence check now runs **after `track_info` is built**, inside `reverse_download_and_process` — which means it covers both the catalog path (`spotify_track_id`) and the manual-metadata path uniformly, instead of only the former. If a file already exists at the target location, the job is marked `"skipped"` and returns immediately — no re-download, no overwrite.

### Why not just reuse the existing `spotify_track_id`-gated check?

That check requires a real catalog ID to fetch `track_info` from Deezer/Spotify before it can compare anything. Forcing every manual-metadata caller to first resolve a catalog match just to get deduping is a lot of complexity for something that should just be a file-existence check — and a bad catalog match can tag the file with the wrong metadata. Moving the check to run on whatever `track_info` is already in hand (catalog-derived or manual) avoids all of that.

### Testing

Verified manually against a running instance:

1. `POST /api/reverse/download` with `skip_if_exists: true` for a track not yet in the library → downloads, tags, copies to Navidrome, job reports `"completed"`.
2. Same exact request again → job reports `"skipped"` with `"Track already exists at the target location, skipped"`, no re-download, existing file untouched.
3. Confirmed default behavior (`skip_if_exists` omitted) is unchanged — still re-downloads/overwrites as before.

### Changes

- `backend/app.py`
  - `ReverseDownloadRequest.skip_if_exists: Optional[bool] = False`
  - `reverse_download_and_process(...)` gains a `skip_if_exists` parameter and an early-return existence check right after `track_info` is resolved
  - `reverse_download` passes `request.skip_if_exists` through to the background task

No breaking changes — new field is optional and defaults to preserving current behavior.
